### PR TITLE
IgnorePropertyの日本語がJavadocに正しく出力されないため説明追記

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ gradle-app.setting
 *.iml
 
 *.log
+
+# Maven
+target/

--- a/src/main/java/nablarch/core/validation/ValidationManager.java
+++ b/src/main/java/nablarch/core/validation/ValidationManager.java
@@ -90,6 +90,8 @@ public class ValidationManager implements Initializable {
     /**
      * メッセージリソースをセットする。
      *
+     * <p><b>MessageUtilのメッセージリソースを使用するよう仕様変更を行ったため本プロパティは廃止しました。(値を設定しても意味がありません)</b>
+     *
      * @param stringResourceHolder メッセージリソース
      */
     @IgnoreProperty("MessageUtilのメッセージリソースを使用するよう仕様変更を行ったため本プロパティは廃止しました。(値を設定しても意味がありません)")


### PR DESCRIPTION
## 背景

`@IgnoreProperty`に指定した日本語メッセージがJavadocに正しく出力されない。

## 対応

利用者が読めるように、同じメッセージをJavadocの説明に追記する。

## 備考

`.gitignore`にMavenの出力先が漏れていたようなので、ついでに追加しました。